### PR TITLE
Character deletion fix + dummy characters in default data

### DIFF
--- a/Patches/AnimationPatch.cs
+++ b/Patches/AnimationPatch.cs
@@ -140,7 +140,7 @@ internal class AnimationPatch
         MappedPlayer p = __instance;
         var overrideController = new AnimatorOverrideController(p.animator.runtimeAnimatorController);
         p.animator.runtimeAnimatorController = overrideController;
-        MappedMenus.screenTim = 0;
+        p.InstantTransition(p.animFile[0], p.frame[0], 0);
     }
     
     /*

--- a/Patches/SaveFilePatch.cs
+++ b/Patches/SaveFilePatch.cs
@@ -635,5 +635,34 @@ internal class SaveFilePatch
             }
         }
     }
+    
+    private static int _origCharCount;
+    
+    /*
+     * Patch:
+     * - Adds dummy characters to the "default data" to prevent index out of range exceptions.
+     */
+    [HarmonyPatch(typeof(SaveData), nameof(SaveData.FCMMKIBFKHK))]
+    [HarmonyPrefix]
+    public static void SaveData_FCMMKIBFKHK_Pre()
+    {
+        _origCharCount = GLPGLJAJJOP.DPACJDJFLKM.savedChars.Length - 1;
+        Array.Resize(ref GLPGLJAJJOP.DPACJDJFLKM.savedChars, Characters.no_chars + 1);
+        for (int i = _origCharCount + 1; i <= Characters.no_chars; i++)
+        {
+            GLPGLJAJJOP.DPACJDJFLKM.savedChars[i] = MappedCharacters.CopyClass(GLPGLJAJJOP.DPACJDJFLKM.savedChars[1]);
+        }
+    }
+    
+    /*
+     * Patch:
+     * - Removes the dummy characters from the "default data" after the default data is loaded.
+     */
+    [HarmonyPatch(typeof(SaveData), nameof(SaveData.FCMMKIBFKHK))]
+    [HarmonyPostfix]
+    public static void SaveData_FCMMKIBFKHK_Post()
+    {
+        Array.Resize(ref GLPGLJAJJOP.DPACJDJFLKM.savedChars, _origCharCount + 1);
+    }
 }
 

--- a/Utils/CharacterUtils.cs
+++ b/Utils/CharacterUtils.cs
@@ -95,6 +95,15 @@ public class CharacterUtils
                 {
                     MappedWeapons.stock[i].owner--;
                 }
+
+                if (MappedWeapons.stock[i].holder == id)
+                {
+                    MappedWeapons.stock[i].holder = 1;
+                }
+                else if (MappedWeapons.stock[i].holder > id)
+                {
+                    MappedWeapons.stock[i].holder--;
+                }
             }
 
             foreach (var character in Characters.c)

--- a/Utils/SaveRemapper.cs
+++ b/Utils/SaveRemapper.cs
@@ -708,6 +708,12 @@ internal class SaveRemapper
                         $"Weapon owner index {stockWeapon.owner} is out of bounds. Resetting to 1.");
                     stockWeapon.owner = 1;
                 }
+                if (stockWeapon.holder > numChars)
+                {
+                    LogWarning(
+                        $"Weapon holder index {stockWeapon.holder} is out of bounds. Resetting to 1.");
+                    stockWeapon.holder = 1;
+                }
             }
         }
         foreach (var character in saveData.savedChars)


### PR DESCRIPTION
Fixed `Stock.holder` not changing when a character gets deleted, leading to broken saves;

Adds dummy characters to the "default data" to prevent index out of range exceptions (The same as for WECCL)