### PR TITLE
Fix for replacing `texture.png` object textures

### DIFF
--- a/Patches/ContentPatch.cs
+++ b/Patches/ContentPatch.cs
@@ -179,17 +179,21 @@ internal class ContentPatch
                         continue;
                     }
                     
-                    if (ResourceOverridesTextures.ContainsKey(material.mainTexture.name.ToLower()) ||
-                        ResourceOverridesTextures.ContainsKey(gameObject.name.Replace("(Clone)", "").Trim().ToLower() + "_" +
-                                                              material.mainTexture.ToString().ToLower()))
+                    string shortTexName = material.mainTexture.name.ToLower();
+                    string longTexName = gameObject.name.Replace("(Clone)", "").Trim().ToLower() + "_" +
+                                                              material.mainTexture.name.ToLower();
+
+                    if (ResourceOverridesTextures.ContainsKey(shortTexName) ||
+                        ResourceOverridesTextures.ContainsKey(longTexName))
                     {
-                        Texture2D tex = GetHighestPriorityTextureOverride(material.mainTexture.name.ToLower());
+                        string texName = (ResourceOverridesTextures.ContainsKey(shortTexName)) ? shortTexName: longTexName;
+                        Texture2D tex = GetHighestPriorityTextureOverride(texName);
                         if ((material.mainTexture.width != tex.width ||
                             material.mainTexture.height != tex.height) &&
                              !Plugin.UseFullQualityTextures.Value)
                         {
                             tex = ResizeTexture(tex, material.mainTexture.width, material.mainTexture.height);
-                            SetHighestPriorityTextureOverride(material.mainTexture.name.ToLower(), tex);
+                            SetHighestPriorityTextureOverride(texName, tex);
                         }
 
                         material.mainTexture = tex;


### PR DESCRIPTION
Intended feature didn't work at all due to bugs. (the same fix as for Wrestling Empire)